### PR TITLE
Add empty check and chains endpoint

### DIFF
--- a/messari/defillama/defillama.py
+++ b/messari/defillama/defillama.py
@@ -20,6 +20,7 @@ DL_GLOBAL_TVL_URL = "https://api.llama.fi/charts/"
 DL_CURRENT_PROTOCOL_TVL_URL = Template("https://api.llama.fi/tvl/$slug")
 DL_CHAIN_TVL_URL = Template("https://api.llama.fi/charts/$chain")
 DL_GET_PROTOCOL_TVL_URL = Template("https://api.llama.fi/protocol/$slug")
+DL_CHAINS_URL = "https://api.llama.fi/chains/"
 
 
 class DeFiLlama(DataLoader):
@@ -209,6 +210,11 @@ class DeFiLlama(DataLoader):
 
         # Join DataFrames from each chain & return
         chains_df = pd.concat(chain_df_list, axis=1)
+
+        # If chains_df is empty, return an empty DataFrame
+        if chains_df.empty:
+            return pd.DataFrame()
+
         chains_df.columns = chains
         chains_df = time_filter_df(chains_df, start_date=start_date, end_date=end_date)
         return chains_df
@@ -258,3 +264,22 @@ class DeFiLlama(DataLoader):
 
         protocols_df = pd.DataFrame(protocol_dict)
         return protocols_df
+
+    def get_chains(self) -> List[str]:
+        """Get the names of all chains supported by Defi Llama
+
+        Used downstream to get the names/TVL of protocols on each chain
+
+        Returns
+        -------
+        List
+            List of chain name strings
+        """
+        chains = self.get_response(DL_CHAINS_URL)
+
+        chain_names = [chain['name'] for chain in chains]
+
+        # Sort chain name results to ensure consistent order
+        chain_names = sorted(chain_names)
+
+        return chain_names


### PR DESCRIPTION
# Summary
## New `/chains` Endpoint
Adding another method to the Defillama class to consume the output from the /chains API [endpoint](https://defillama.com/docs/api).

This will allow us to programmatically get the TVL and/or names of all protocols for a specific chain.

Sorting the results to ensure that they're returned consistently between runs.

## Empty Check for `get_chain_tvl_timeseries`
When grabbing data from get_chain_tvl_timeseries() for certain chains, the global TVL data can come back empty (ran into this for OntologyEVM)

To fix this, check to see if the global TVL results are empty and return an empty pd.DataFrame before assigning column names.

# Tests

New endpoint
<img width="1104" alt="image" src="https://user-images.githubusercontent.com/29241719/183771039-856e0c36-ee93-494c-ad3a-806eb577df6b.png">
Results before the check
<img width="1506" alt="Screen Shot 2022-06-06 at 3 42 23 PM" src="https://user-images.githubusercontent.com/29241719/172235820-3e6e7ca2-ee82-4fc8-9f21-ef0d0171f060.png">

Results after the check is added
<img width="985" alt="Screen Shot 2022-06-06 at 3 41 09 PM" src="https://user-images.githubusercontent.com/29241719/172235870-849ae4b6-02dd-4853-863c-225b734a2c0c.png">


`get_chain_tvl_timeseries()` works for all chains returned when calling the `/chains` [endpoint](https://defillama.com/docs/api) on Defillama
<img width="597" alt="image" src="https://user-images.githubusercontent.com/29241719/172245316-a018eaa8-a42a-4775-b372-19e3e8d13c22.png">

